### PR TITLE
Version 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] / 2022-04-28
+### Fixed
+- Remove `result` from `CallAsync` response.
+### Added
+- Add `CallAsync<MessageResponse>()` on Example
+
 ## [1.0.0] / 2022-04-24
 - First Release
 
-[vNext]: ../../compare/1.0.0...HEAD
+[1.1.0]: ../../compare/1.0.0...1.1.0
 [1.0.0]: ../../compare/1.0.0

--- a/Firebase.Functions.Example/Program.cs
+++ b/Firebase.Functions.Example/Program.cs
@@ -67,10 +67,17 @@ namespace Firebase.Functions.Example
                     });
 
                 var function = functions.GetHttpsCallable(FirebaseCallFunction);
-                Console.WriteLine($"CallAsync: {FirebaseCallFunction}");
 
+                Console.WriteLine($"CallAsync: {FirebaseCallFunction}");
                 var response = await function.CallAsync();
                 Console.WriteLine($"CallResponse: {response}");
+
+                if (FirebaseCallFunction == "Test")
+                {
+                    Console.WriteLine($"CallAsync<MessageResponse>: {FirebaseCallFunction}");
+                    var responseMessage = await function.CallAsync<MessageResponse>();
+                    Console.WriteLine($"CallResponse<MessageResponse>.Message: {responseMessage.Message}");
+                }
 
                 Console.WriteLine($"DeleteAnonymously");
                 await authProvider.DeleteUserAsync(auth.FirebaseToken);
@@ -99,5 +106,10 @@ namespace Firebase.Functions.Example
             }
             return str;
         }
+    }
+
+    internal class MessageResponse
+    {
+        public string Message { get; set; }
     }
 }

--- a/Firebase.Functions/Firebase.Functions.csproj
+++ b/Firebase.Functions/Firebase.Functions.csproj
@@ -29,7 +29,7 @@
     <AssemblyName>Firebase.Functions</AssemblyName>
     <PackageId>FirebaseFunctions.net</PackageId>
     <GitHubId>firebase-functions-dotnet</GitHubId>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Firebase.Functions/HttpsCallableReference.cs
+++ b/Firebase.Functions/HttpsCallableReference.cs
@@ -39,7 +39,8 @@
             var httpClient = await firebaseFunctions.CreateHttpClientAsync();
             var responseMessage = await httpClient.PostAsync(name, CreateHttpContent(data));
             var content = await responseMessage.Content.ReadAsStringAsync();
-            return content;
+            var firebaseResult = JsonConvert.DeserializeObject<FirebaseResult>(content, firebaseFunctions.Options.JsonSerializerSettings);
+            return firebaseResult.Result.ToString();
         }
 
         /// <summary>
@@ -76,13 +77,13 @@
         /// <summary>
         /// FirebaseData
         /// </summary>
-        public class FirebaseData
+        internal class FirebaseData
         {
             /// <summary>
             /// FirebaseData
             /// </summary>
             /// <param name="data"></param>
-            public FirebaseData(object data)
+            internal FirebaseData(object data)
             {
                 this.Data = data;
             }
@@ -92,6 +93,18 @@
             /// </summary>
             [JsonProperty("data")]
             public object Data { get; set; }
+        }
+
+        /// <summary>
+        /// FirebaseResult
+        /// </summary>
+        internal class FirebaseResult
+        {
+            /// <summary>
+            /// Result
+            /// </summary>
+            [JsonProperty("result")]
+            public object Result { get; set; }
         }
     }
 }


### PR DESCRIPTION
### Fixed
- Remove `result` from `CallAsync` response.
### Added
- Add `CallAsync<MessageResponse>()` on Example